### PR TITLE
Fix Unit Restart Issue #43

### DIFF
--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractDALUnitController.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractDALUnitController.java
@@ -116,7 +116,7 @@ public abstract class AbstractDALUnitController<M extends AbstractMessage & Seri
     }
 
     @Override
-    public synchronized void deactivate() throws InterruptedException, CouldNotPerformException {
+    public void deactivate() throws InterruptedException, CouldNotPerformException {
         super.deactivate();
 
         // deactivate data source


### PR DESCRIPTION
Fix Unit Restart Issue #43

### :scroll: Description

Changes proposed in this pull request:
* Remove a synchronized statement from a deactivate method which was likely outdated. That this could produce the bug/deadlock has been proven. ***It remains to be tested that this completely fixed the issue***.
