### PR TITLE
Bugfix/#77 review protobuf merge from usage to avoid list entry duplication

### DIFF
--- a/module/api/graphql/src/main/java/org/openbase/bco/api/graphql/schema/RegistrySchemaModule.java
+++ b/module/api/graphql/src/main/java/org/openbase/bco/api/graphql/schema/RegistrySchemaModule.java
@@ -40,6 +40,7 @@ import org.openbase.bco.registry.remote.session.BCOSessionImpl;
 import org.openbase.bco.registry.unit.lib.filter.UnitConfigFilterImpl;
 import org.openbase.bco.registry.unit.remote.UnitRegistryRemote;
 import org.openbase.jul.exception.CouldNotPerformException;
+import org.openbase.jul.extension.protobuf.ProtoBufBuilderProcessor;
 import org.openbase.jul.extension.type.processing.LabelProcessor;
 import org.openbase.jul.pattern.Filter;
 import org.openbase.jul.pattern.ListFilter;
@@ -139,12 +140,11 @@ public class RegistrySchemaModule extends SchemaModule {
     @Mutation("updateUnitConfig")
     UnitConfig updateUnitConfig(@Arg("unitConfig") UnitConfig unitConfig) throws BCOGraphQLError {
         try {
-            unitConfig = Registries.getUnitRegistry(ServerError.BCO_TIMEOUT_SHORT, ServerError.BCO_TIMEOUT_TIME_UNIT)
+            final UnitConfig.Builder unitConfigBuilder = Registries.getUnitRegistry(ServerError.BCO_TIMEOUT_SHORT, ServerError.BCO_TIMEOUT_TIME_UNIT)
                     .getUnitConfigById(unitConfig.getId())
-                    .toBuilder()
-                    .mergeFrom(unitConfig)
-                    .build();
-            return Registries.getUnitRegistry(ServerError.BCO_TIMEOUT_SHORT, ServerError.BCO_TIMEOUT_TIME_UNIT).updateUnitConfig(unitConfig).get(ServerError.BCO_TIMEOUT_SHORT, ServerError.BCO_TIMEOUT_TIME_UNIT);
+                    .toBuilder();
+            ProtoBufBuilderProcessor.mergeFromWithoutRepeatedFields(unitConfigBuilder, unitConfig);
+            return Registries.getUnitRegistry(ServerError.BCO_TIMEOUT_SHORT, ServerError.BCO_TIMEOUT_TIME_UNIT).updateUnitConfig(unitConfigBuilder.build()).get(ServerError.BCO_TIMEOUT_SHORT, ServerError.BCO_TIMEOUT_TIME_UNIT);
         } catch (RuntimeException | CouldNotPerformException | InterruptedException | ExecutionException | TimeoutException ex) {
             throw new GenericError(ex);
         }

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/action/ActionImpl.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/action/ActionImpl.java
@@ -300,14 +300,7 @@ public class ActionImpl implements SchedulableAction {
                                 }
 
                                 // apply new state
-                                actionDescriptionBuilderLock.lockWriteInterruptibly();
-                                try {
-                                    actionDescriptionBuilder.mergeFrom(
-                                        unit.performOperationService(serviceState, serviceDescription.getServiceType()).get(EXECUTION_FAILURE_TIMEOUT, TimeUnit.MILLISECONDS)
-                                    );
-                                } finally {
-                                    actionDescriptionBuilderLock.unlockWrite();
-                                }
+                                unit.performOperationService(serviceState, serviceDescription.getServiceType()).get(EXECUTION_FAILURE_TIMEOUT, TimeUnit.MILLISECONDS);
 
                                 updateActionStateIfNotCanceled(State.EXECUTING);
 

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
@@ -1040,7 +1040,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
                     }
 
                     // skip further steps if no actions are scheduled
-                    if (!atLeastOneActionToSchedule) {
+                     if (!atLeastOneActionToSchedule) {
                         logger.debug("No valid action on stack, so finish scheduling.");
                         return null;
                     }

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
@@ -1040,7 +1040,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
                     }
 
                     // skip further steps if no actions are scheduled
-                     if (!atLeastOneActionToSchedule) {
+                    if (!atLeastOneActionToSchedule) {
                         logger.debug("No valid action on stack, so finish scheduling.");
                         return null;
                     }

--- a/module/dal/lib/src/main/java/org/openbase/bco/dal/lib/action/ActionDescriptionProcessor.java
+++ b/module/dal/lib/src/main/java/org/openbase/bco/dal/lib/action/ActionDescriptionProcessor.java
@@ -12,6 +12,7 @@ import org.openbase.jul.exception.InvalidStateException;
 import org.openbase.jul.exception.NotAvailableException;
 import org.openbase.jul.exception.VerificationFailedException;
 import org.openbase.jul.exception.printer.ExceptionPrinter;
+import org.openbase.jul.extension.protobuf.ProtoBufBuilderProcessor;
 import org.openbase.jul.extension.type.processing.LabelProcessor;
 import org.openbase.jul.extension.type.processing.MultiLanguageTextProcessor;
 import org.openbase.jul.extension.type.processing.TimestampProcessor;
@@ -1136,7 +1137,7 @@ public class ActionDescriptionProcessor {
             actionParameter.setExecutionTimePeriod(timeUnit.toMicros(executionTimePeriod));
 
             if (actionInitiator != null) {
-                actionParameter.getActionInitiatorBuilder().mergeFrom(actionInitiator);
+                ProtoBufBuilderProcessor.mergeFromWithoutRepeatedFields(actionParameter.getActionInitiatorBuilder(), actionInitiator);
             }
 
             return generateAndSetResponsibleAction(serviceStateBuilder, targetUnit, actionParameter);

--- a/module/registry/util/src/main/java/org/openbase/bco/registry/mock/MockRegistry.java
+++ b/module/registry/util/src/main/java/org/openbase/bco/registry/mock/MockRegistry.java
@@ -45,6 +45,7 @@ import org.openbase.jul.exception.InvalidStateException;
 import org.openbase.jul.exception.printer.ExceptionPrinter;
 import org.openbase.jul.exception.printer.LogLevel;
 import org.openbase.jul.extension.protobuf.IdentifiableMessage;
+import org.openbase.jul.extension.protobuf.ProtoBufBuilderProcessor;
 import org.openbase.jul.extension.protobuf.container.ProtoBufMessageMap;
 import org.openbase.jul.extension.type.processing.LabelProcessor;
 import org.openbase.jul.processing.StringProcessor;
@@ -283,7 +284,7 @@ public class MockRegistry {
                     LOGGER.debug("Update serviceTemplates...");
                     for (MockServiceTemplate mockServiceTemplate : MockServiceTemplate.values()) {
                         final ServiceTemplate.Builder originalServiceTemplate = Registries.getTemplateRegistry().getServiceTemplateByType(mockServiceTemplate.getServiceTemplate().getServiceType()).toBuilder();
-                        originalServiceTemplate.mergeFrom(mockServiceTemplate.getServiceTemplate());
+                        ProtoBufBuilderProcessor.mergeFromWithoutRepeatedFields(originalServiceTemplate, mockServiceTemplate.getServiceTemplate());
                         Registries.getTemplateRegistry().updateServiceTemplate(originalServiceTemplate.build()).get();
                     }
 
@@ -291,7 +292,7 @@ public class MockRegistry {
                     // load templates
                     for (MockUnitTemplate template : MockUnitTemplate.values()) {
                         final UnitTemplate.Builder originalUnitTemplate = Registries.getTemplateRegistry().getUnitTemplateByType(template.getUnitTemplate().getUnitType()).toBuilder();
-                        originalUnitTemplate.mergeFrom(template.getUnitTemplate());
+                        ProtoBufBuilderProcessor.mergeFromWithoutRepeatedFields(originalUnitTemplate, template.getUnitTemplate());
                         Registries.getTemplateRegistry().updateUnitTemplate(originalUnitTemplate.build()).get();
                     }
 


### PR DESCRIPTION
Based on: openbase/jul#

### :scroll: Description

* remove`mergeForm` usage in `ActionImpl`
* replace all `mergeFrom` usages by `mergeFromWithoutRepeatedFields` that is now provided by `jul`.