### PR TITLE
Bugfix/#69 fix action pipeline deadlocks and other issues that cause random action cancelations.

### DIFF
--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/action/ActionImpl.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/action/ActionImpl.java
@@ -69,8 +69,10 @@ public class ActionImpl implements SchedulableAction {
     protected final AbstractUnitController<?, ?> unit;
     private final SyncObject executionStateChangeSync = new SyncObject("ExecutionStateChangeSync");
 
-    // any code that accesses the data lock while holding the action task lock should previously lock the data lock.
-    // otherwise deadlocks can occur.
+    // IMPORTANT LOCKING NOTE: There is no need to acquire the actionDescriptionBuilderLock in every case we need the action task exclusively.
+    // However, in case you acquire the action task lock and need to access the actionDescriptionBuilder within its synchronize scope,
+    // the actionDescriptionBuilderLock has to be acquired first before locking the action task.
+    // Otherwise, there is a high risk of deadlocks.
     private final SyncObject actionTaskLock = new SyncObject("ActionTaskLock");
     private final BundledReentrantReadWriteLock actionDescriptionBuilderLock;
     private ActionDescription.Builder actionDescriptionBuilder;

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
@@ -1720,7 +1720,9 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
             }
 
             // final reschedule for cleanup
-            reschedule();
+            if(!isShutdownInProgress()) {
+                reschedule();
+            }
         } finally {
             builderSetup.unlockWrite(NotificationStrategy.AFTER_LAST_RELEASE);
         }

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/scene/SceneControllerImpl.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/scene/SceneControllerImpl.java
@@ -316,7 +316,7 @@ public class SceneControllerImpl extends AbstractBaseUnitController<SceneData, B
                                 // if the timeout is exhausted then just continue since we want to keep on trying as long as the scene is active.
                                 continue;
                             } catch (CancellationException | CouldNotPerformException ex) {
-                                ExceptionPrinter.printHistory("Required " + requiredAction + " of " + getLabel("?") + " could not executed!", ex, logger, LogLevel.DEBUG);
+                                ExceptionPrinter.printHistory("Required " + requiredAction + " of " + getLabel("?") + " could not be executed!", ex, logger, LogLevel.DEBUG);
                                 return FutureProcessor.canceledFuture(ActionDescription.class, new RejectedException("Required action " + requiredAction + " could not be executed", ex));
                             }
                         }

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/scene/SceneControllerImpl.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/scene/SceneControllerImpl.java
@@ -329,7 +329,7 @@ public class SceneControllerImpl extends AbstractBaseUnitController<SceneData, B
                                 // if the timeout is exhausted than just continue since we want to keep on trying as long as the scene is active.
                                 continue;
                             } catch (CancellationException | CouldNotPerformException ex) {
-                                ExceptionPrinter.printHistory("Optional " + optionalAction + " of " + getLabel("?") + " could not executed!", ex, logger, LogLevel.TRACE);
+                                ExceptionPrinter.printHistory("Optional " + optionalAction + " of " + getLabel("?") + " could not be executed!", ex, logger, LogLevel.TRACE);
                             }
                         }
 
@@ -463,10 +463,10 @@ public class SceneControllerImpl extends AbstractBaseUnitController<SceneData, B
             }
 
             if (!responsibleAction.isValid()) {
-                throw new VerificationFailedException("The activation of "+getLabel("?") + " is not valid anymore.");
+                throw new VerificationFailedException("The activation of " + getLabel("?") + " is not valid anymore.");
             }
 
-            // skip in case to service state was delivered
+            // skip in case no service state was delivered
             if(serviceState.toString().isBlank()) {
                 return;
             }

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/scene/SceneControllerImpl.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/scene/SceneControllerImpl.java
@@ -334,7 +334,6 @@ public class SceneControllerImpl extends AbstractBaseUnitController<SceneData, B
                         }
 
                         // register an observer which will deactivate the scene if one required action is now longer running
-                        // observer will cleanup itself after the action is no longer valid so no need to care fore it.
                         try {
                             actionObserver = new RequiredActionObserver(requiredActionImpactList, getActionById(responsibleActionBuilder.getActionId(), "SceneController"));
                         } catch (NotAvailableException ex) {
@@ -437,7 +436,7 @@ public class SceneControllerImpl extends AbstractBaseUnitController<SceneData, B
 
         private void verifyAllStates() {
             try {
-                // logger.trace("verify "+unitAndRequiredServiceStateMap.entrySet().size()+ " states of "+ getLabel("?"));
+                logger.trace(() -> "verify "+unitAndRequiredServiceStateMap.entrySet().size()+ " states of "+ getLabel("?"));
                 for (Entry<UnitRemote<? extends Message>, RequiredServiceDescription> unitActionReferenceEntry : unitAndRequiredServiceStateMap.entrySet()) {
                     try {
                         // skip unit in case its offline, since then the verification is automatically
@@ -472,7 +471,7 @@ public class SceneControllerImpl extends AbstractBaseUnitController<SceneData, B
             }
 
             if (!Services.equalServiceStates(unitAndRequiredServiceStateMap.get(unit).getServiceState(), serviceState)) {
-                // LOGGER.warn(unitAndRequiredServiceStateMap.get(unit).getServiceState() + " is not equals " + serviceState.toString().substring(0, 20) + " and will cancel: " + SceneControllerImpl.this.getLabel("?"));
+                logger.trace(() -> unitAndRequiredServiceStateMap.get(unit).getServiceState() + " is not equals " + serviceState.toString().substring(0, 20) + " and will cancel: " + SceneControllerImpl.this.getLabel("?"));
                 if(Actions.validateInitialAction(serviceState)) {
                     throw new VerificationFailedException("State of " + unit + "not meet!");
                 }
@@ -493,7 +492,6 @@ public class SceneControllerImpl extends AbstractBaseUnitController<SceneData, B
         @Override
         public void update(ServiceStateProvider<Message> serviceStateProvider, Message serviceState) throws Exception {
             try {
-                // logger.error("Incomming service state update from "+ serviceStateProvider.getServiceProvider().getId() + " triggered from "+ serviceState.toString());
                 verifyState(serviceStateProvider.getServiceProvider(), serviceState);
             } catch (VerificationFailedException ex) {
                 unsatisfiedState();

--- a/module/dal/lib/src/main/java/org/openbase/bco/dal/lib/layer/service/Services.java
+++ b/module/dal/lib/src/main/java/org/openbase/bco/dal/lib/layer/service/Services.java
@@ -1259,7 +1259,7 @@ public class Services extends ServiceStateProcessor {
         }
 
         // fail if only one is empty
-        if (serviceState1.equals(serviceState1.getDefaultInstanceForType()) || serviceState2.equals(serviceState2.getDefaultInstanceForType())) {
+        if (serviceState1.equals(serviceState1.getDefaultInstanceForType()) ^ serviceState2.equals(serviceState2.getDefaultInstanceForType())) {
             return false;
         }
 
@@ -1373,5 +1373,3 @@ public class Services extends ServiceStateProcessor {
         return serviceState.getClass().getName();
     }
 }
-
-

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/Actions.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/Actions.java
@@ -63,7 +63,7 @@ public class Actions {
         try {
             return validateInitialAction(ServiceStateProcessor.getResponsibleAction(serviceState));
         } catch (CouldNotPerformException e) {
-            // skip validation is error case.
+            // skip validation in error case.
         }
         return false;
     }

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
@@ -838,13 +838,8 @@ public class RemoteAction implements Action {
      * All information about the action itself will be kept to still enable action state requests.
      */
     private void cleanup() {
-
-        LOGGER.info("cleanup {}", this);
-
         // cancel observation task
         if (futureObservationTask != null && !futureObservationTask.isDone()) {
-
-            LOGGER.error("d");
             StackTracePrinter.printStackTrace(LOGGER);
             futureObservationTask.cancel(true);
         }

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
@@ -840,7 +840,6 @@ public class RemoteAction implements Action {
     private void cleanup() {
         // cancel observation task
         if (futureObservationTask != null && !futureObservationTask.isDone()) {
-            StackTracePrinter.printStackTrace(LOGGER);
             futureObservationTask.cancel(true);
         }
 

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
@@ -261,7 +261,7 @@ public class RemoteAction implements Action {
             }
 
             if (force) {
-                // we do not need to cancel a running actions because its rejected on the target unit anyway when the new action is executed.
+                // we do not need to cancel a running action because it is rejected on the target unit anyway when the new action is executed.
                 reset();
             }
 

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
@@ -818,7 +818,6 @@ public class RemoteAction implements Action {
      * Method resets the entire action remote. After calling no further action states are available.
      */
     public void reset() {
-        LOGGER.warn("reset");
         cleanup();
 
         // reset auto extension task

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
@@ -1217,12 +1217,12 @@ public class RemoteAction implements Action {
      */
     @Override
     public String toString() {
-        String description;
+        String description = null;
         try {
             // use action description for printing since it offers most detailed information about the action
             description = ActionDescriptionProcessor.toString(getActionDescription());
         } catch (NotAvailableException e) {
-            description = "";
+            // continue with next resolution strategy
         }
 
         // resolve via reference

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteAction.java
@@ -36,6 +36,7 @@ import org.openbase.jul.exception.*;
 import org.openbase.jul.exception.printer.ExceptionPrinter;
 import org.openbase.jul.exception.printer.LogLevel;
 import org.openbase.jul.extension.protobuf.processing.ProtoBufFieldProcessor;
+import org.openbase.jul.extension.type.processing.MultiLanguageTextProcessor;
 import org.openbase.jul.extension.type.processing.TimestampProcessor;
 import org.openbase.jul.pattern.ObservableImpl;
 import org.openbase.jul.pattern.Observer;
@@ -75,6 +76,7 @@ public class RemoteAction implements Action {
     private final AuthToken authToken;
     private final List<RemoteAction> impactedRemoteActions = new ArrayList<>();
 
+    private Future<ActionDescription> cleanupTask = null;
     private final Observer unitObserver = (source, data) -> {
 
         // check if initial actionDescription is available
@@ -259,7 +261,7 @@ public class RemoteAction implements Action {
             }
 
             if (force) {
-                // we do not need to cancel a running actions because its rejected on the target unit anyway when a the new action is executed.
+                // we do not need to cancel a running actions because its rejected on the target unit anyway when the new action is executed.
                 reset();
             }
 
@@ -670,7 +672,6 @@ public class RemoteAction implements Action {
         }
     }
     private Future<ActionDescription> internalCancel() {
-        LOGGER.debug("cancel {}", this);
         Future<ActionDescription> future = null;
         try {
             synchronized (executionSync) {
@@ -684,21 +685,19 @@ public class RemoteAction implements Action {
 
                 // if future operation is still running then...
                 if (futureObservationTask != null && !futureObservationTask.isDone()) {
-
-                    if (targetUnit != null && (actionDescription != null || actionReference != null || (actionId != null && serviceType != null))) {
-                        // cancel observation
-                        futureObservationTask.cancel(true);
-                    } else {
-                        try {
-                            futureObservationTask.get(2, TimeUnit.SECONDS);
-                        } catch (InterruptedException ex) {
-                            Thread.currentThread().interrupt();
-                        } catch (Exception ex) {
-                            // continue with other
-                            ExceptionPrinter.printHistory("Could not wait for action description!", ex, LOGGER, LogLevel.DEBUG);
-                        } finally {
-                            futureObservationTask.cancel(true);
+                    try {
+                        if (!(targetUnit != null && (actionDescription != null || actionReference != null || (actionId != null && serviceType != null)))) {
+                            try {
+                                futureObservationTask.get(2, TimeUnit.SECONDS);
+                            } catch (InterruptedException ex) {
+                                Thread.currentThread().interrupt();
+                            } catch (Exception ex) {
+                                // continue with other
+                                ExceptionPrinter.printHistory("Could not wait for action description!", ex, LOGGER, LogLevel.DEBUG);
+                            }
                         }
+                    } finally {
+                        futureObservationTask.cancel(true);
                     }
                 }
 
@@ -753,18 +752,22 @@ public class RemoteAction implements Action {
                 // otherwise create cleanup task
                 final Future<ActionDescription> passthroughFuture = future;
                 try {
-                    return GlobalCachedExecutorService.submit(() -> {
-                        try {
-                            return passthroughFuture.get(10, TimeUnit.SECONDS);
-                        } catch (InterruptedException ex) {
-                            throw ex;
-                        } catch (ExecutionException | java.util.concurrent.TimeoutException ex) {
-                            throw new CouldNotProcessException("Could not cancel " + RemoteAction.this.toString(), ex);
-                        } finally {
-                            // clear
-                            cleanup();
-                        }
-                    });
+                    if(cleanupTask == null || cleanupTask.isDone()) {
+                        cleanupTask = GlobalCachedExecutorService.submit(() -> {
+                            try {
+                                return passthroughFuture.get(10, TimeUnit.SECONDS);
+                            } catch (InterruptedException ex) {
+                                throw ex;
+                            } catch (ExecutionException | java.util.concurrent.TimeoutException ex) {
+                                throw new CouldNotProcessException("Could not cancel " + RemoteAction.this.toString(), ex);
+                            } finally {
+                                // clear
+                                if(!cleanupTask.isCancelled()) {
+                                    cleanup();
+                                }
+                            }
+                        });
+                    }
                 } catch (RejectedExecutionException ex) {
                     return FutureProcessor.canceledFuture(ActionDescription.class, ex);
                 }
@@ -798,7 +801,7 @@ public class RemoteAction implements Action {
     private Future<ActionDescription> registerPostActionStateUpdate(@NonNull final Future<ActionDescription> future, @NonNull final ActionState.State actionState) {
         return FutureProcessor.postProcess((result, time, timeUnit) -> {
 
-            // when all sub actions are canceled, than we can mark this intermediary action as canceled as well.
+            // when all sub actions are canceled, then we can mark this intermediary action as canceled as well.
             if (result != null) {
                 result = result.toBuilder().setActionState(ActionState.newBuilder().setValue(actionState)).build();
             }
@@ -815,6 +818,7 @@ public class RemoteAction implements Action {
      * Method resets the entire action remote. After calling no further action states are available.
      */
     public void reset() {
+        LOGGER.warn("reset");
         cleanup();
 
         // reset auto extension task
@@ -836,10 +840,13 @@ public class RemoteAction implements Action {
      */
     private void cleanup() {
 
-        LOGGER.debug("cleanup {}", this);
+        LOGGER.info("cleanup {}", this);
 
         // cancel observation task
         if (futureObservationTask != null && !futureObservationTask.isDone()) {
+
+            LOGGER.error("d");
+            StackTracePrinter.printStackTrace(LOGGER);
             futureObservationTask.cancel(true);
         }
 
@@ -873,6 +880,10 @@ public class RemoteAction implements Action {
         // reset cancel task after the cleanup is done
         synchronized (cancelLock) {
             cancelTask = null;
+        }
+
+        if(cleanupTask != null) {
+            cleanupTask.cancel(true);
         }
     }
 
@@ -923,7 +934,7 @@ public class RemoteAction implements Action {
             }
         }
 
-        // if this action is not listed on its target unit and its not just the initial sync where the action id is maybe not yet listed,
+        // if this action is not listed on its target unit and it`s not just the initial sync where the action id is maybe not yet listed,
         // then we can be sure that this action is an outdated one and the remote action can be cleaned up.
         if (!initialSync) {
             cleanup();
@@ -948,7 +959,7 @@ public class RemoteAction implements Action {
                 return;
             }
         } catch (NotAvailableException ex) {
-            // if the action description is not available, than we just continue and wait for it.
+            // if the action description is not available, then we just continue and wait for it.
         }
 
         synchronized (executionSync) {
@@ -1118,7 +1129,7 @@ public class RemoteAction implements Action {
                         futureObservationTask.get(timeSplit.getTime(), timeSplit.getTimeUnit());
                     }
                 } catch (CancellationException ex) {
-                    throw new CouldNotPerformException(ex.getCause());
+                    throw new CouldNotPerformException(ex);
                 } catch (java.util.concurrent.TimeoutException ex) {
                     throw new org.openbase.jul.exception.TimeoutException();
                 }
@@ -1213,24 +1224,25 @@ public class RemoteAction implements Action {
      */
     @Override
     public String toString() {
-
+        String description;
         try {
             // use action description for printing since it offers most detailed information about the action
-            return ActionDescriptionProcessor.toString(getActionDescription());
+            description = ActionDescriptionProcessor.toString(getActionDescription());
         } catch (NotAvailableException e) {
+            description = "";
+        }
 
-            // resolve via reference
-            if (actionReference != null) {
-                return ActionDescriptionProcessor.toString(actionReference);
-            }
+        // resolve via reference
+        if (description == null && actionReference != null) {
+            description = ActionDescriptionProcessor.toString(actionReference);
+        }
 
-            // resolve via parameter
-            if (actionParameter != null) {
-                return ActionDescriptionProcessor.toString(actionParameter);
-            }
+        // resolve via parameter
+        if (description == null && actionParameter != null) {
+            description = ActionDescriptionProcessor.toString(actionParameter);
         }
 
         // use default as fallback
-        return Action.toString(this);
+        return Action.toString(this) + " - " + description;
     }
 }

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteActionPool.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/action/RemoteActionPool.java
@@ -176,26 +176,34 @@ public class RemoteActionPool {
 
 
     public void waitUntilDone() throws CouldNotPerformException, InterruptedException {
-        for (final RemoteAction action : remoteActionList) {
-            action.waitUntilDone();
+        synchronized (actionListSync) {
+            for (final RemoteAction action : remoteActionList) {
+                action.waitUntilDone();
+            }
         }
     }
 
     public void waitForRegistration() throws CouldNotPerformException, InterruptedException {
-        for (final RemoteAction action : remoteActionList) {
-            action.waitForRegistration();
+        synchronized (actionListSync) {
+            for (final RemoteAction action : remoteActionList) {
+                action.waitForRegistration();
+            }
         }
     }
 
     public void addActionDescriptionObserver(final Observer<RemoteAction, ActionDescription> observer) {
-        for (final RemoteAction action : remoteActionList) {
-            action.addActionDescriptionObserver(observer);
+        synchronized (actionListSync) {
+            for (final RemoteAction action : remoteActionList) {
+                action.addActionDescriptionObserver(observer);
+            }
         }
     }
 
     public void removeActionDescriptionObserver(final Observer<RemoteAction, ActionDescription> observer) {
-        for (final RemoteAction action : remoteActionList) {
-            action.removeActionDescriptionObserver(observer);
+        synchronized (actionListSync) {
+            for (final RemoteAction action : remoteActionList) {
+                action.removeActionDescriptionObserver(observer);
+            }
         }
     }
 

--- a/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/layer/unit/AbstractUnitRemote.java
+++ b/module/dal/remote/src/main/java/org/openbase/bco/dal/remote/layer/unit/AbstractUnitRemote.java
@@ -138,15 +138,21 @@ public abstract class AbstractUnitRemote<D extends Message> extends AbstractAuth
 
                 final Set<ServiceType> serviceTypeSet = new HashSet<>();
                 for (final ServiceDescription serviceDescription : AbstractUnitRemote.this.getUnitTemplate().getServiceDescriptionList()) {
-                    if (serviceDescription.getPattern() == ServicePattern.PROVIDER && serviceTempus == ServiceTempus.REQUESTED) {
+
+                    // a requested state observation only makes sense if the state can be modified.
+                    if (serviceTempus == ServiceTempus.REQUESTED && serviceDescription.getPattern() != ServicePattern.OPERATION) {
                         continue;
                     }
+
                     // check if already handled
                     if (serviceTypeSet.contains(serviceDescription.getServiceType())) {
                         continue;
                     }
+
+                    // register service type as handled.
                     serviceTypeSet.add(serviceDescription.getServiceType());
 
+                    // perform service notification based on new data.
                     try {
                         Message serviceData = (Message) Services.invokeServiceMethod(serviceDescription.getServiceType(), ServicePattern.PROVIDER, serviceTempus, data1);
                         serviceTempusServiceTypeObservableMap.get(serviceTempus).get(serviceDescription.getServiceType()).notifyObservers(serviceData);

--- a/module/dal/test/src/main/java/org/openbase/bco/dal/test/AbstractBCOTest.java
+++ b/module/dal/test/src/main/java/org/openbase/bco/dal/test/AbstractBCOTest.java
@@ -83,12 +83,19 @@ public abstract class AbstractBCOTest extends MqttIntegrationTest {
         }
     }
 
+    @BeforeEach
+    public void notifyAboutTestStart() {
+        LOGGER.info("===================================== Start BCO Test =====================================");
+    }
+
     /**
      * Method is automatically called after each test run and there is no need to call it manually.
      * If you want to cancel all actions manually please use method {@code cancelAllTestActions()} to get feedback about the cancellation process.
      */
     @AfterEach
     public void autoCancelActionsAfterTestRun() {
+
+        LOGGER.info("===================================== Finish BCO Test =====================================");
 
         // before canceling pending actions lets just validate that the test did not cause any deadlocks
         assertFalse(StackTracePrinter.detectDeadLocksAndPrintStackTraces(LOGGER), "Deadlocks found!");

--- a/module/dal/test/src/test/java/org/openbase/bco/dal/test/layer/unit/scene/SceneRemoteTest.java
+++ b/module/dal/test/src/test/java/org/openbase/bco/dal/test/layer/unit/scene/SceneRemoteTest.java
@@ -573,9 +573,9 @@ public class SceneRemoteTest extends AbstractBCOTest {
         for (int i = 0; i <= TEST_ITERATIONS; i++) {
             System.out.println("Current iteration: " + i);
 
-            LOGGER.warn("turn on...");
+            LOGGER.debug("turn on...");
             waitForExecution(sceneRemoteOn.setActivationState(State.ACTIVE, SCENE_ACTION_PARAM));
-            LOGGER.warn("turn on... continue ");
+            LOGGER.debug("turn on... continue ");
 
             internalLight.requestData().get();
             internalPowerSwitch.requestData().get();
@@ -587,9 +587,9 @@ public class SceneRemoteTest extends AbstractBCOTest {
             assertEquals(State.ACTIVE, sceneRemoteOn.getActivationState().getValue(), "Location on scene is not active");
             assertEquals(State.INACTIVE, sceneRemoteOff.getActivationState().getValue(), "Location off scene is not inactive");
 
-            LOGGER.warn("turn off...");
+            LOGGER.debug("turn off...");
             waitForExecution(sceneRemoteOff.setActivationState(State.ACTIVE, SCENE_ACTION_PARAM));
-            LOGGER.warn("turn off... continue");
+            LOGGER.debug("turn off... continue");
 
             internalLight.requestData().get();
             internalPowerSwitch.requestData().get();
@@ -601,7 +601,7 @@ public class SceneRemoteTest extends AbstractBCOTest {
             assertEquals(State.INACTIVE, sceneRemoteOn.getActivationState().getValue(), "Location on scene is not inactive");
             assertEquals(State.ACTIVE, sceneRemoteOff.getActivationState().getValue(), "Location off scene is not active");
 
-            System.out.println("=== " + (int) (((double) i / (double) TEST_ITERATIONS) * 100d) + "% passed with iteration " + i + " of location on off test.");
+            LOGGER.debug("=== " + (int) (((double) i / (double) TEST_ITERATIONS) * 100d) + "% passed with iteration " + i + " of location on off test.");
         }
     }
 

--- a/module/dal/test/src/test/java/org/openbase/bco/dal/test/layer/unit/scene/SceneRemoteTest.java
+++ b/module/dal/test/src/test/java/org/openbase/bco/dal/test/layer/unit/scene/SceneRemoteTest.java
@@ -573,7 +573,9 @@ public class SceneRemoteTest extends AbstractBCOTest {
         for (int i = 0; i <= TEST_ITERATIONS; i++) {
             System.out.println("Current iteration: " + i);
 
+            LOGGER.warn("turn on...");
             waitForExecution(sceneRemoteOn.setActivationState(State.ACTIVE, SCENE_ACTION_PARAM));
+            LOGGER.warn("turn on... continue ");
 
             internalLight.requestData().get();
             internalPowerSwitch.requestData().get();
@@ -585,7 +587,9 @@ public class SceneRemoteTest extends AbstractBCOTest {
             assertEquals(State.ACTIVE, sceneRemoteOn.getActivationState().getValue(), "Location on scene is not active");
             assertEquals(State.INACTIVE, sceneRemoteOff.getActivationState().getValue(), "Location off scene is not inactive");
 
+            LOGGER.warn("turn off...");
             waitForExecution(sceneRemoteOff.setActivationState(State.ACTIVE, SCENE_ACTION_PARAM));
+            LOGGER.warn("turn off... continue");
 
             internalLight.requestData().get();
             internalPowerSwitch.requestData().get();


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* fix potential deadlock between actionDescriptionBuilderLock and actionTaskLock in ActionImpl.
* make sure reschedule is not triggered once the unit controller is shutting down to avoid lots of exceptions.
* Make sure required state observer is shutdown in case the scene state changes to not interfere with future scene activations. Improve required state validation by filtering by validate the initial action to avoid scene cancelation based on an outdated action. Minor typo fixes.
* fix logic issue in equalServiceStates check.
* Implement validateInitialAction service method for Actions.
* Make sure remote action cleanup task does not cleanup the state of other actions that are later observed by the same remote instance, by canceling the cleanup task once the remote is reinitialized.
* make sure remote action list is always locked once accessed.
* Code readability improvements.
* clearly define start and end of an bco test to enable the separation of test prints vs. setup / cleanup prints.
* improve test logging.