### PR TITLE
80 skip sending actions to openhab if they do not cause a state change

### DIFF
--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
@@ -10,12 +10,12 @@ package org.openbase.bco.dal.control.layer.unit;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -27,7 +27,6 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import lombok.val;
 import org.openbase.bco.authentication.lib.*;
 import org.openbase.bco.authentication.lib.AuthenticatedServiceProcessor.InternalIdentifiedProcessable;
 import org.openbase.bco.authentication.lib.AuthorizationHelper.PermissionType;
@@ -115,7 +114,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.openbase.type.domotic.service.ServiceTemplateType.ServiceTemplate.ServicePattern.OPERATION;
 import static org.openbase.type.domotic.service.ServiceTemplateType.ServiceTemplate.ServicePattern.PROVIDER;
@@ -123,7 +121,6 @@ import static org.openbase.type.domotic.service.ServiceTemplateType.ServiceTempl
 /**
  * @param <D>  the data type of this unit used for the state synchronization.
  * @param <DB> the builder used to build the unit data instance.
- *
  * @author <a href="mailto:divine@openbase.org">Divine Threepwood</a>
  */
 public abstract class AbstractUnitController<D extends AbstractMessage & Serializable, DB extends D.Builder<DB>> extends AbstractAuthenticatedConfigurableController<D, DB, UnitConfig> implements UnitController<D, DB> {
@@ -685,9 +682,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      * @param actionId     the id of the action retrieved.
      * @param lockConsumer string identifying the task. Required because this method has to lock the builder setup because
      *                     of access to the {@link #scheduledActionList}.
-     *
      * @return the action identified by the provided id as described above.
-     *
      * @throws NotAvailableException if not action with the provided id could be found.
      */
     public SchedulableAction getActionById(final String actionId, final String lockConsumer) throws NotAvailableException, InterruptedException {
@@ -719,7 +714,6 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      *
      * @param userId the id of the user whose permissions are checked.
      * @param action the action checked.
-     *
      * @throws PermissionDeniedException if the user has no permissions to modify the provided action.
      * @throws CouldNotPerformException  if the permissions check could not be performed.
      */
@@ -729,7 +723,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
                 userId = User.OTHER;
             }
 
-            if(action.getId().equals(terminatingActionId)) {
+            if (action.getId().equals(terminatingActionId)) {
                 throw new InvalidStateException("Its not allowed to cancel the termination action!");
             }
 
@@ -893,7 +887,6 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      *
      * @return the {@code action} which is ranked highest and which is therefore currently allocating this unit.
      * If there is no action left to schedule null is returned.
-     *
      * @throws CouldNotPerformException is throw in case the scheduling is currently not possible, e.g. because of a system shutdown.
      */
     public Action reschedule() throws CouldNotPerformException, InterruptedException {
@@ -905,10 +898,8 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      * If the current action is not finished it will be rejected.
      *
      * @param actionToSchedule a new action to schedule. If null it will be ignored.
-     *
      * @return the {@code action} which is ranked highest and which is therefore currently allocating this unit.
      * If there is no action left to schedule null is returned.
-     *
      * @throws CouldNotPerformException is throw in case the scheduling is currently not possible, e.g. because of a system shutdown.
      */
     private Action reschedule(final SchedulableAction actionToSchedule) throws CouldNotPerformException, InterruptedException {
@@ -1139,7 +1130,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
     public void notifyScheduledActionList() throws InterruptedException {
 
         // skip notification when builder setup is locked since then the notification is performed anyway.
-        if(!builderSetup.tryLockWrite(10, TimeUnit.SECONDS, LOCK_CONSUMER_NOTIFICATION)) {
+        if (!builderSetup.tryLockWrite(10, TimeUnit.SECONDS, LOCK_CONSUMER_NOTIFICATION)) {
             logger.warn("Skip action list sync since builder setup is busy.");
             // todo: we might want to mark the data object as dirty, since the action list is not up to date in this case.
             return;
@@ -1162,7 +1153,6 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      * Syncs the action list into the given {@code dataBuilder}.
      *
      * @param dataBuilder used to synchronize with.
-     *
      * @throws CouldNotPerformException is thrown if the sync failed.
      */
     private void syncActionList(final DB dataBuilder) throws CouldNotPerformException {
@@ -1360,7 +1350,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
 
 
         for (SchedulableAction schedulableAction : new ArrayList<>(scheduledActionList)) {
-            if(!schedulableAction.isDone()) {
+            if (!schedulableAction.isDone()) {
                 schedulableAction.reject();
             }
         }
@@ -1432,7 +1422,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
             }
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
-            throw new CouldNotPerformException("Update was interrupted!",ex);
+            throw new CouldNotPerformException("Update was interrupted!", ex);
         } catch (Exception ex) {
             throw new CouldNotPerformException("Could not apply Service[" + serviceType.name() + "] Update[" + newState + "] for " + this + "!", ex);
         }
@@ -1489,9 +1479,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      * @param serviceState    the prototype of the new state.
      * @param serviceType     the service type of the new state.
      * @param internalBuilder the builder object used to access the currently applied state.
-     *
      * @return the computed state.
-     *
      * @throws RejectedException        in case the state would not change anything compared to the current one.
      * @throws CouldNotPerformException if the state could not be computed.
      */
@@ -1714,13 +1702,13 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
 
                 // cancel all other actions on the stack
                 final Action removedAction = scheduledActionList.remove(i);
-                if(!removedAction.isDone()) {
+                if (!removedAction.isDone()) {
                     removedAction.cancel();
                 }
             }
 
             // final reschedule for cleanup
-            if(!isShutdownInProgress()) {
+            if (!isShutdownInProgress()) {
                 reschedule();
             }
         } finally {
@@ -1776,7 +1764,6 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      *
      * @param internalBuilder The data builder of this unit which already contains the updated state.
      * @param serviceType     The service type which has been updated.
-     *
      * @throws InterruptedException is thrown if the thread is externally interrupted.
      */
     protected void applyCustomDataUpdate(DB internalBuilder, ServiceType serviceType) throws InterruptedException {
@@ -1864,9 +1851,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      * otherwise the parent location remote is returned which refers the location where this unit is placed in.
      *
      * @param waitForData flag defines if the method should block until the remote is fully synchronized.
-     *
      * @return a location remote instance.
-     *
      * @throws NotAvailableException          is thrown if the location remote is currently not available.
      * @throws java.lang.InterruptedException is thrown if the current was externally interrupted.
      */
@@ -1918,9 +1903,9 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
     public void activate() throws InterruptedException, CouldNotPerformException {
         super.activate();
         // in test mode we should directly reschedule so the termination action takes place.
-        if(JPService.testMode()) {
+        if (JPService.testMode()) {
             try {
-                if(!terminatingActionId.equals(TERMINATION_ACTION_NOT_AVAILABLE)) {
+                if (!terminatingActionId.equals(TERMINATION_ACTION_NOT_AVAILABLE)) {
                     getActionById(terminatingActionId, getClass().getSimpleName()).execute().get(3, TimeUnit.SECONDS);
                 }
             } catch (CouldNotPerformException | ExecutionException | TimeoutException ex) {
@@ -1934,7 +1919,6 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      *
      * @param serviceType      the type of the new service.
      * @param operationService the service which performes the operation.
-     *
      * @throws CouldNotPerformException is thrown if the type of the service is already registered.
      */
     protected void registerOperationService(final ServiceType serviceType, final OperationService operationService) throws CouldNotPerformException {
@@ -1968,7 +1952,6 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
      *
      * @param serviceState {@inheritDoc}
      * @param serviceType  {@inheritDoc}
-     *
      * @return {@inheritDoc}
      */
     @Override
@@ -1995,6 +1978,8 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
                 if (Services.equalServiceStates(
                         serviceState,
                         Services.invokeProviderServiceMethod(serviceType, operationService))) {
+                    // apply the service state which updates the responsible action
+                    applyDataUpdate(serviceState, serviceType);
                     return FutureProcessor.completedFuture(ServiceStateProcessor.getResponsibleAction(serviceState, ActionDescription::getDefaultInstance));
                 }
 
@@ -2018,7 +2003,7 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
             }
 
             // handle invalid case
-            return FutureProcessor.canceledFuture(ActionDescription.class, new CouldNotPerformException("Operation service for type[" + serviceType.name() + "] not registered for "+ this));
+            return FutureProcessor.canceledFuture(ActionDescription.class, new CouldNotPerformException("Operation service for type[" + serviceType.name() + "] not registered for " + this));
 
         } catch (CouldNotPerformException ex) {
             return FutureProcessor.canceledFuture(ActionDescription.class, ex);

--- a/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
+++ b/module/dal/control/src/main/java/org/openbase/bco/dal/control/layer/unit/AbstractUnitController.java
@@ -1991,6 +1991,13 @@ public abstract class AbstractUnitController<D extends AbstractMessage & Seriali
                     }
                 }
 
+                // skip invoking the operation service if the new state matches the current state
+                if (Services.equalServiceStates(
+                        serviceState,
+                        Services.invokeProviderServiceMethod(serviceType, operationService))) {
+                    return FutureProcessor.completedFuture(ServiceStateProcessor.getResponsibleAction(serviceState, ActionDescription::getDefaultInstance));
+                }
+
                 // invoke operation service routine
                 return (Future<ActionDescription>) Services.invokeOperationServiceMethod(serviceType, operationService, serviceState);
             }


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Applying operation services (e.g., sending events to OpenHAB) is now skipped if they match the current state.

