### PR TITLE
Updater for HA addon version

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -37,7 +37,7 @@ jobs:
           tags: |
             type=schedule
             type=raw,value=preview+{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
-            type=raw,value={{branch}}+{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=startsWith(github.ref, 'refs/heads/')
+            type=raw,value={{branch}}+{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=${{ startsWith(github.ref, 'refs/heads/') }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -16,8 +16,10 @@ on:
 
 jobs:
   docker:
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'preview') }}
     runs-on: ubuntu-latest
+    outputs:
+      bco-tags: ${{ steps.bco-meta.outputs.tags }}
     steps:
       -
         name: Checkout
@@ -34,7 +36,8 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
-            type=raw,value=review,enable=${{ contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
+            type=raw,value=preview+{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
+            type=raw,value={{branch}}+{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=startsWith(github.ref, 'refs/heads/')
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
@@ -67,7 +70,7 @@ jobs:
           context: .
           file: docker/Dockerfile 
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
+          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'preview') }}
           tags: ${{ steps.bco-meta.outputs.tags }}
           labels: ${{ steps.bco-meta.outputs.labels }}
         env:
@@ -84,7 +87,7 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
-            type=raw,value=review,enable=${{ contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
+            type=raw,value=preview,enable=${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
@@ -103,7 +106,7 @@ jobs:
             BCO_BASE_IMAGE_VERSION=sha-${{ steps.short-sha.outputs.sha }}
           file: ./docker/device-manager/openhab/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
+          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'preview') }}
           tags: ${{ steps.bco-device-meta.outputs.tags }}
           labels: ${{ steps.bco-device-meta.outputs.labels }}
       -
@@ -118,7 +121,7 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
-            type=raw,value=review,enable=${{ contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
+            type=raw,value=review,enable=${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
@@ -134,7 +137,7 @@ jobs:
             BCO_BASE_IMAGE_VERSION=sha-${{ steps.short-sha.outputs.sha }}
           file: ./docker/bco-demo/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
+          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'preview') }}
           tags: ${{ steps.bco-demo-meta.outputs.tags }}
           labels: ${{ steps.bco-demo-meta.outputs.labels }}
 
@@ -145,5 +148,30 @@ jobs:
     uses: ./.github/workflows/update-addon-version.yaml
     with:
       version: ${{ github.ref_name }}
+      addons: "bco-core"
+    secrets:
+      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-addon-version-dev:
+    name: Update Home Assistant Add-on Version
+    needs: docker
+    if: startsWith(github.ref, 'refs/heads/dev')
+    uses: ./.github/workflows/update-addon-version.yaml
+    with:
+      addons: "bco-core"
+      tags: ${{ needs.docker.outputs.bco-tags }}
+      track: dev
+    secrets:
+      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    update-addon-version-preview:
+    name: Update Home Assistant Add-on Version
+    needs: docker
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    uses: ./.github/workflows/update-addon-version.yaml
+    with:
+      addons: "bco-core"
+      tags: ${{ needs.docker.outputs.bco-tags }}
+      track: preview
     secrets:
       CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -150,7 +150,7 @@ jobs:
       version: ${{ github.ref_name }}
       addon: "bco-core"
     secrets:
-      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
   update-addon-version-dev:
     name: Update Home Assistant Add-on Version
@@ -162,7 +162,7 @@ jobs:
       tags: ${{ needs.docker.outputs.bco-tags }}
       track: dev
     secrets:
-      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
   update-addon-version-preview:
     name: Update Home Assistant Add-on Version
@@ -174,4 +174,4 @@ jobs:
       tags: ${{ needs.docker.outputs.bco-tags }}
       track: preview
     secrets:
-      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -164,14 +164,14 @@ jobs:
     secrets:
       CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    update-addon-version-preview:
-      name: Update Home Assistant Add-on Version
-      needs: docker
-      if: contains(github.event.pull_request.labels.*.name, 'preview')
-      uses: ./.github/workflows/update-addon-version.yaml
-      with:
-        addons: "bco-core"
-        tags: ${{ needs.docker.outputs.bco-tags }}
-        track: preview
-      secrets:
-        CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  update-addon-version-preview:
+    name: Update Home Assistant Add-on Version
+    needs: docker
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    uses: ./.github/workflows/update-addon-version.yaml
+    with:
+      addons: "bco-core"
+      tags: ${{ needs.docker.outputs.bco-tags }}
+      track: preview
+    secrets:
+      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -165,13 +165,13 @@ jobs:
       CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     update-addon-version-preview:
-    name: Update Home Assistant Add-on Version
-    needs: docker
-    if: contains(github.event.pull_request.labels.*.name, 'preview')
-    uses: ./.github/workflows/update-addon-version.yaml
-    with:
-      addons: "bco-core"
-      tags: ${{ needs.docker.outputs.bco-tags }}
-      track: preview
-    secrets:
-      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      name: Update Home Assistant Add-on Version
+      needs: docker
+      if: contains(github.event.pull_request.labels.*.name, 'preview')
+      uses: ./.github/workflows/update-addon-version.yaml
+      with:
+        addons: "bco-core"
+        tags: ${{ needs.docker.outputs.bco-tags }}
+        track: preview
+      secrets:
+        CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -36,8 +36,8 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
-            type=raw,value=preview+{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
-            type=raw,value={{branch}}+{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=${{ startsWith(github.ref, 'refs/heads/') }}
+            type=raw,value=preview-{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
+            type=raw,value={{branch}}-{{commit_date 'YYYYMMDD-HHmmss' tz='UTC'}},enable=${{ startsWith(github.ref, 'refs/heads/') }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/update-addon-version.yaml
     with:
       version: ${{ github.ref_name }}
-      addons: "bco-core"
+      addon: "bco-core"
     secrets:
       CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -158,7 +158,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/dev')
     uses: ./.github/workflows/update-addon-version.yaml
     with:
-      addons: "bco-core"
+      addon: "bco-core"
       tags: ${{ needs.docker.outputs.bco-tags }}
       track: dev
     secrets:
@@ -170,7 +170,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     uses: ./.github/workflows/update-addon-version.yaml
     with:
-      addons: "bco-core"
+      addon: "bco-core"
       tags: ${{ needs.docker.outputs.bco-tags }}
       track: preview
     secrets:

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   docker:
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'preview') }}
+    # if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'preview') }}
     runs-on: ubuntu-latest
     outputs:
       bco-tags: ${{ steps.bco-meta.outputs.tags }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -137,3 +137,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'prebuild docker image') }}
           tags: ${{ steps.bco-demo-meta.outputs.tags }}
           labels: ${{ steps.bco-demo-meta.outputs.labels }}
+
+  update-addon-version:
+    name: Update Home Assistant Add-on Version
+    needs: docker
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/update-addon-version.yaml
+    with:
+      version: ${{ github.ref_name }}
+    secrets:
+      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-addon-version.yaml
+++ b/.github/workflows/update-addon-version.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "Searching for tag for track: $TRACK"
 
           if [ -n "$TRACK" ]; then
-            MATCHED_TAG=$(printf "%s\n" "$LIST" \
+            MATCHED_TAG=$(printf "%s\n" "$TAGS" \
               | sed -n "s/.*:${TRACK}+\([^[:space:]]*\).*/${TRACK}+\\1/p" \
               | sort -u \
               | head -n1)
@@ -61,7 +61,7 @@ jobs:
             exit 1
           else
             echo "No track specified, skipping tag selection."
-            echo "SELECTED_TAG="" >> $GITHUB_OUTPUT
+            echo 'SELECTED_TAG=""' >> $GITHUB_OUTPUT
           fi
 
       - name: Update add-on versions

--- a/.github/workflows/update-addon-version.yaml
+++ b/.github/workflows/update-addon-version.yaml
@@ -27,8 +27,8 @@ jobs:
         env:
           ADDONS_DIR: "bco-core"
           VERSION: "${{ inputs.version }}"
-          GIT_USERNAME: "The Cat[bot]"
-          GIT_EMAIL: "thecat[bot]@users.noreply.github.com"
+          GIT_USERNAME: "Minou [bot]"
+          GIT_EMAIL: "minou[bot]@users.noreply.github.com"
         run: |
           cd addons-repo/$ADDONS_DIR
 

--- a/.github/workflows/update-addon-version.yaml
+++ b/.github/workflows/update-addon-version.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout addon repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           repository: openbase/homeassistant.addons.bco

--- a/.github/workflows/update-addon-version.yaml
+++ b/.github/workflows/update-addon-version.yaml
@@ -1,0 +1,49 @@
+name: Home Assistant Add-ons Update
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'The version to set for the add-ons'
+        required: true
+        type: string
+    secrets:
+      CI_GITHUB_TOKEN:
+        description: 'CI GitHub token'
+        required: true
+
+jobs:
+  update-addons:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout addon repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: openbase/homeassistant.addons.bco
+          path: addons-repo
+
+      - name: Update add-on versions
+        env:
+          ADDONS_DIR: "bco-core"
+          VERSION: "${{ inputs.version }}"
+          GIT_USERNAME: "The Cat[bot]"
+          GIT_EMAIL: "thecat[bot]@users.noreply.github.com"
+        run: |
+          cd addons-repo/$ADDONS_DIR
+
+          # Update version in config.yaml
+          sed -i "s/^version: .*/version: $VERSION/" config.yaml
+
+          # Commit and push changes
+          git config user.name "$GIT_USERNAME"
+          git config user.email "$GIT_EMAIL"
+          git add config.yaml
+          git commit -m "Update add-on $ADDONS_DIR version to $VERSION" || {
+            echo "No changes to commit"
+            exit 0
+          }
+
+          git push
+
+          echo "✅ Add-on $ADDONS_DIR version updated to $VERSION and changes pushed."

--- a/.github/workflows/update-addon-version.yaml
+++ b/.github/workflows/update-addon-version.yaml
@@ -5,8 +5,23 @@ on:
     inputs:
       version:
         description: 'The version to set for the add-ons'
+        required: false
+        type: string
+        default: ""
+      addon:
+        description: 'The add-on to update'
         required: true
         type: string
+      tags:
+        description: 'The tags associated with the version'
+        required: false
+        type: string
+        default: ""
+      track:
+        description: 'The track associated with the version'
+        required: false
+        type: string
+        default: ""
     secrets:
       CI_GITHUB_TOKEN:
         description: 'CI GitHub token'
@@ -23,14 +38,55 @@ jobs:
           repository: openbase/homeassistant.addons.bco
           path: addons-repo
 
+      - name: Dig up tag
+        id: dig-up-tag
+        env:
+          TAGS: "${{ inputs.tags }}"
+          TRACK: "${{ inputs.track }}"
+        run: |
+          echo "Received TAGS: $TAGS"
+          echo "Searching for tag for track: $TRACK"
+
+          if [ -n "$TRACK" ]; then
+            MATCHED_TAG=$(printf "%s\n" "$LIST" \
+              | sed -n "s/.*:${TRACK}+\([^[:space:]]*\).*/${TRACK}+\\1/p" \
+              | sort -u \
+              | head -n1)
+            if [ -n "$MATCHED_TAG" ]; then
+              echo "Found matching tag: $MATCHED_TAG"
+              echo "SELECTED_TAG=$MATCHED_TAG" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "No tag found for track '$TRACK'. Exiting with error."
+            exit 1
+          else
+            echo "No track specified, skipping tag selection."
+            echo "SELECTED_TAG="" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update add-on versions
         env:
-          ADDONS_DIR: "bco-core"
-          VERSION: "${{ inputs.version }}"
+          ADDON: "${{ inputs.addon }}"
+          TRACK: "${{ inputs.track }}" 
           GIT_USERNAME: "Minou [bot]"
           GIT_EMAIL: "minou[bot]@users.noreply.github.com"
         run: |
-          cd addons-repo/$ADDONS_DIR
+
+          if [ -z $TRACK ]; then
+            echo "No track specified, using default folder."
+            if [ -z "${{ inputs.version }}" ]; then
+              echo "No version specified, exiting with error."
+              exit 1
+            fi
+            VERSION="${{ inputs.version }}"
+            ADDON_DIR="${ADDON}"
+          else
+            echo "Track specified: ${TRACK}, using ${TRACK} folder."
+            VERSION="${{ steps.dig-up-tag.outputs.SELECTED_TAG }}"
+            ADDON_DIR="${ADDON}-${TRACK}"
+          fi
+
+          cd addons-repo/$ADDON_DIR
 
           # Update version in config.yaml
           sed -i "s/^version: .*/version: $VERSION/" config.yaml
@@ -46,4 +102,4 @@ jobs:
 
           git push
 
-          echo "✅ Add-on $ADDONS_DIR version updated to $VERSION and changes pushed."
+          echo "✅ Add-on $ADDON_DIR version updated to $VERSION and changes pushed."

--- a/.github/workflows/update-addon-version.yaml
+++ b/.github/workflows/update-addon-version.yaml
@@ -49,7 +49,7 @@ jobs:
 
           if [ -n "$TRACK" ]; then
             MATCHED_TAG=$(printf "%s\n" "$LIST" \
-              | sed -n "s/.*:${TRACK}+\([^[:space:]]*\).*/${TRACK}+\\1/p" \
+              | sed -n "s/.*:${TRACK}-\([^[:space:]]*\).*/${TRACK}-\\1/p" \
               | sort -u \
               | head -n1)
             if [ -n "$MATCHED_TAG" ]; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,29 +1,22 @@
-# Install dependencies
-FROM eclipse-temurin:21-jdk AS builder
+# syntax=docker/dockerfile:1.7
 
-ENV \
-    JAVA_OPTS="" \
-    LC_ALL="en_US.UTF-8" \
-    LANG="en_US.UTF-8" \
-    LANGUAGE="en_US.UTF-8"
-
+############################################
+# Stage 1 — Build with a lightweight JDK
+############################################
+ARG JAVA_VERSION=21
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-alpine AS build
 WORKDIR /workspace
 
-# Setup build deps
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && \
-    apt install -y \
-            git \
-            gradle \
-            rsync \
-            curl \
-            ca-certificates \
-            locales \
-            locales-all \
-            wget && \
-    apt clean
+# Optional: useful for Gradle plugins that invoke git, etc.
+RUN apk add --no-cache git
 
-# Copy repo into working directory
+# Install bash
+RUN apk add --no-cache bash
+
+# Speed up builds with a persistent Gradle cache (BuildKit required)
+ENV GRADLE_USER_HOME=/home/gradle/.gradle
+
+# Now copy sources and build for real
 COPY . .
 
 # Setup Gradle Wrapper
@@ -37,22 +30,22 @@ RUN cd lib/jul && \
 # Build bco
 RUN ./gradlew :bco.app.util:installDist -x test -x javadoc --no-daemon --stacktrace
 
-# Switch to baseline image
-FROM eclipse-temurin:21-jre
+
+############################################
+# Stage 2 — Minimal runtim
+############################################
+FROM eclipse-temurin:21-jre AS runtime
 
 # # Install app
-COPY --from=builder /workspace/module/app/util/build/install/bco/bin /usr/bin/
-COPY --from=builder /workspace/module/app/util/build/install/bco/lib /usr/lib/
-# COPY --from=builder /workspace/build/share /usr/share/
+COPY --from=build /workspace/module/app/util/build/install/bco/bin /usr/bin/
+COPY --from=build /workspace/module/app/util/build/install/bco/lib /usr/lib/
 
 # Install runtime deps
-## gosu: required to switch to another user ofter entrypoint is started as root.
 ## tini: required to forward app signals such as sigint.
 RUN apt update && \
     apt install -y software-properties-common && \
     apt update && \
     apt install -y \
-            gosu \
             gnupg \
             tini \
             fontconfig \
@@ -66,7 +59,7 @@ RUN apt update && \
 
 # Set variables and locales
 ENV \
-    JAVA_OPTS="" \
+    JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
@@ -79,17 +72,16 @@ ENV \
     BCO_OPTIONS="--host ${MQTT_BROKER}"
 
 # Basic build-time metadata as defined at http://label-schema.org
-LABEL org.label-schema.build-date=$BUILD_DATE \
-    org.label-schema.docker.dockerfile="docker/Dockerfile" \
+LABEL org.label-schema.docker.dockerfile="docker/Dockerfile" \
     org.label-schema.license="GPL3" \
     org.label-schema.name="bco" \
     org.label-schema.vendor="openbase.org" \
-    org.label-schema.version=$VERSION \
     org.label-schema.description="A behaviour based smart environment plattform" \
     org.label-schema.url="https://www.basecubeone.org" \
-    org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/openbase/bco.git" \
+    io.hass.type="addon" \
+    io.hass.arch="aarch64|amd64" \
     maintainer="Divine Threepwood <divine@openbase.org>"
 
 # Expose volume
@@ -105,17 +97,9 @@ RUN ln -s /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-# TODO: probably deprecated by setting the variables BCO_LOGS above
-# Configure logger
-# COPY logback-debug.xml /etc/bco/
-# COPY logback.xml /etc/bco/
-
 # Configure healthcheck
 # todo: make sure only the registry availability is checks since devices are not maintained by this instance.
 HEALTHCHECK --interval=15m --timeout=2m CMD bco-validate --host ${MQTT_BROKER} > /dev/null || exit 1
-
-# switch to root, let the entrypoint drop back to bco user
-USER root
 
 # Set command
 ## Need to be in array form to not encapsulate command in another shell session because

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,7 @@ ENV \
     BCO_LOGS="/home/bco/data/log" \
     BCO_BINARY="/usr/bin/bco" \
     MQTT_BROKER="mqtt-broker" \
-    BCO_OPTIONS="--host ${MQTT_BROKER}"
+    BCO_OPTIONS=""
 
 # Basic build-time metadata as defined at http://label-schema.org
 LABEL org.label-schema.docker.dockerfile="docker/Dockerfile" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,7 @@ ENV \
     BCO_LOGS="/home/bco/data/log" \
     BCO_BINARY="/usr/bin/bco" \
     MQTT_BROKER="mqtt-broker" \
-    BCO_OPTIONS=""
+    BCO_OPTIONS="--"
 
 # Basic build-time metadata as defined at http://label-schema.org
 LABEL org.label-schema.docker.dockerfile="docker/Dockerfile" \

--- a/docker/bco-demo/Dockerfile
+++ b/docker/bco-demo/Dockerfile
@@ -27,15 +27,12 @@ ENV \
     BCO_MODULE_PREPARE_SCRIPT="bco-module-prepare.sh"
 
 # Basic build-time metadata as defined at http://label-schema.org
-LABEL org.label-schema.build-date=$BUILD_DATE \
-    org.label-schema.docker.dockerfile="/docker/bco-demo/Dockerfile" \
+LABEL org.label-schema.docker.dockerfile="/docker/bco-demo/Dockerfile" \
     org.label-schema.license="GPL3" \
     org.label-schema.name="bco-test" \
     org.label-schema.vendor="openbase.org" \
-    org.label-schema.version=$VERSION \
     org.label-schema.description="The BCO Demo downloads the demo db and starts bco in test mode." \
     org.label-schema.url="https://www.basecubeone.org" \
-    org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/openbase/bco.git" \
     maintainer="Divine Threepwood <divine@openbase.org>"
@@ -50,11 +47,7 @@ RUN mkdir -p /usr/share/bco/
 COPY --from=builder /workspace/db /usr/share/bco/db/
 
 # Configure healthcheck
-# todo: make sure only device offered by this device manager are checked
 HEALTHCHECK --interval=15m --timeout=2m CMD bco-validate --host ${MQTT_BROKER} >/dev/null || exit 1
-
-# switch to root, let the entrypoint drop back to bco user
-USER root
 
 # Set command
 CMD ["bco-test"]

--- a/docker/bco-demo/Dockerfile
+++ b/docker/bco-demo/Dockerfile
@@ -22,8 +22,7 @@ FROM openbaseorg/bco:${BCO_BASE_IMAGE_VERSION}
 # Set variables and locales
 ENV \
     JAVA_OPTS="" \
-    OPENHAB_CONF="/etc/openhab2" \
-    BCO_OPTIONS="--db /tmp/bco/db --host ${MQTT_BROKER}" \
+    BCO_OPTIONS="--db /tmp/bco/db" \
     BCO_MODULE_PREPARE_SCRIPT="bco-module-prepare.sh"
 
 # Basic build-time metadata as defined at http://label-schema.org

--- a/docker/device-manager/openhab/Dockerfile
+++ b/docker/device-manager/openhab/Dockerfile
@@ -9,15 +9,12 @@ ENV \
     BCO_MODULE_PREPARE_SCRIPT="bco-module-prepare.sh"
 
 # Basic build-time metadata as defined at http://label-schema.org
-LABEL org.label-schema.build-date=$BUILD_DATE \
-    org.label-schema.docker.dockerfile="/docker/device-manager/openhab/Dockerfile" \
+LABEL org.label-schema.docker.dockerfile="/docker/device-manager/openhab/Dockerfile" \
     org.label-schema.license="GPL3" \
     org.label-schema.name="bco-device-manager-openhab" \
     org.label-schema.vendor="openbase.org" \
-    org.label-schema.version=$VERSION \
     org.label-schema.description="The BCO Device Manager connects all openhab devices to the bco infrastructure." \
     org.label-schema.url="https://www.basecubeone.org" \
-    org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/openbase/bco.git" \
     maintainer="Divine Threepwood <divine@openbase.org>"
@@ -33,9 +30,6 @@ RUN ln -s /usr/local/bin/${BCO_MODULE_PREPARE_SCRIPT} && \
 # Configure healthcheck
 # todo: make sure only device offered by this device manager are checked
 HEALTHCHECK --interval=15m --timeout=2m CMD bco-validate  --host ${MQTT_BROKER} >/dev/null || exit 1
-
-# switch to root, let the entrypoint drop back to bco user
-USER root
 
 # Set command
 CMD ["bco-manager-device-openhab"]

--- a/docker/device-manager/openhab/bco-module-prepare.sh
+++ b/docker/device-manager/openhab/bco-module-prepare.sh
@@ -1,22 +1,3 @@
 #!/bin/bash
 
-OPENHAB_USER_NAME="openhab"
-
-# Prepare sitemap folder access
-if [ -z ${OPENHAB_GROUP_ID+x} ]; then
-    echo "openhab group id not set! Therefore, sitemap permissions can not be guaranteed.";
-else
-    # skip creation if already exist
-    if [ -z "$(getent group $OPENHAB_GROUP_ID)" ]; then
-        echo "add bco user to openhab group to guarantee sitemap folder access...";
-
-        # create openhab group within the container
-        groupadd -g ${OPENHAB_GROUP_ID} ${OPENHAB_USER_NAME}
-
-        # register bco user as member of the openhab group
-        usermod -a -G ${OPENHAB_USER_NAME} ${BCO_USER}
-    fi
-
-    # make sure openhab group can modify existing configurations
-    chmod -R g+rw ${OPENHAB_CONF} 
-fi
+echo "nothing to prepare for openhab device manager..."

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 set -- tini -s -- "$@"
 
 # Prepare log directory
-mkdir -p ${BCO_LOGS}
+mkdir -p "${BCO_LOGS}"
 
 # Prepare bco modules if required
 if [ -z ${BCO_MODULE_PREPARE_SCRIPT+x} ]; then
@@ -21,5 +21,5 @@ fi
 # replace the current pid 1 with original entrypoint
 echo "start main application: $@"
 
-set -- "$@" --bco-home ${BCO_HOME} --log-dir ${BCO_LOGS} ${BCO_OPTIONS} -v
+set -- "$@" --bco-home "${BCO_HOME}" --log-dir "${BCO_LOGS}" --host "${MQTT_BROKER}" "${BCO_OPTIONS}"
 exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,34 +7,8 @@ set -euo pipefail
 # configure script to call original entrypoint
 set -- tini -s -- "$@"
 
-# Add bco user
-BCO_USER_ID=${USER_ID:-9002}
-BCO_GROUP_ID=${GROUP_ID:-$BCO_USER_ID}
-echo "Starting with ${BCO_USER} user id: $BCO_USER_ID and group id: $BCO_GROUP_ID"
-if ! id -u ${BCO_USER} >/dev/null 2>&1; then
-  if [ -z "$(getent group $BCO_GROUP_ID)" ]; then
-    echo "Create group ${BCO_USER} with id ${BCO_GROUP_ID}"
-    groupadd -g $BCO_GROUP_ID ${BCO_USER}
-  else
-    group_name=$(getent group $BCO_GROUP_ID | cut -d: -f1)
-    echo "Rename group $group_name to ${BCO_USER}"
-    groupmod --new-name ${BCO_USER} $group_name
-  fi
-  echo "Create user bco with id ${BCO_USER_ID}"
-  adduser -u $BCO_USER_ID --disabled-password --gecos '' --home "${BCO_USER_HOME}" --gid $BCO_GROUP_ID ${BCO_USER}
-fi
-
-# Set bco directory permission
-chown -R ${BCO_USER}:${BCO_USER} "${BCO_USER_HOME}"
-sync
-
-# Add call to gosu to drop from root user to bco user
-# when running original entrypoint
-set -- gosu ${BCO_USER} "$@"
-
 # Prepare log directory
 mkdir -p ${BCO_LOGS}
-chown -R ${BCO_USER} ${BCO_LOGS} 
 
 # Prepare bco modules if required
 if [ -z ${BCO_MODULE_PREPARE_SCRIPT+x} ]; then


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:

- Adds workflow that updates the `bco-core` version in the `homeassistant.addons.bco` repo
- This workflow will be triggered after the docker containers are build and pushed ~~, but right now only if this workflow was triggered by push on tag that starts with `v`~~ supports addon tracks stable, dev, preview
- dev and preview will now be tagged with a timestamp (eg. dev+20251012073021)